### PR TITLE
Added resolution() function; screenshot now returns a PIL image

### DIFF
--- a/android_controller/android_controller.py
+++ b/android_controller/android_controller.py
@@ -1,5 +1,7 @@
 import subprocess
-
+import re
+from PIL import Image
+from io import BytesIO
 
 
 def checkConnections():
@@ -16,9 +18,11 @@ def checkConnections():
             rtrn.append(connection[0])
     return rtrn
 
-def connect(host : str):
+
+def connect(host: str):
     subprocess.run(["adb", "connect", host])
     return
+
 
 def disconnect(host: str = "all"):
     if host == "all":
@@ -27,13 +31,16 @@ def disconnect(host: str = "all"):
         subprocess.run(["adb", "connect", host])
     return
 
+
 def tap(x: int, y: int):
     subprocess.run(["adb", "shell", "input", "tap", str(x), str(y)])
     return
 
+
 def swipe(x1: int, y1: int, x2: int, y2: int):
     subprocess.run(["adb", "shell", "input", "swipe", str(x1), str(y1), str(x2), str(y2)])
     return
+
 
 def keyEvent(key: str, longpress: bool = False):
     if longpress:
@@ -43,6 +50,21 @@ def keyEvent(key: str, longpress: bool = False):
         subprocess.run(["adb", "shell", "input", key])
         return
 
-def screenshot(outputpath: str):
-    subprocess.run(["adb", "exec-out", "screencap", "-p", ">", outputpath])
-    return outputpath
+
+def resolution():
+    process = subprocess.Popen(["adb", "shell", "wm", "size"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    output = process.stdout.read().decode("utf-8")
+    resolution = re.search(r"(\d+)x(\d+)", output)
+    return tuple(map(int, resolution.groups()))
+
+
+def screenshot(outputpath: str = None):
+    # image = PIL.import PIL
+    process = subprocess.Popen(["adb", "exec-out", "screencap", "-p"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    image_data = process.stdout.read()
+    stream = BytesIO(image_data)
+    image = Image.open(stream).convert("RGBA")
+    stream.close()
+    if outputpath:
+        image.save(outputpath, "PNG")
+    return image


### PR DESCRIPTION
`screenshot()` method now returns a PIL image.

This is useful if we want to process the image and not save it to disk every time.
`outputpath` parameter is now optional in order to do so.